### PR TITLE
refactor and export get_address_type()

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,7 @@ npm install bitcoin-address
 
 > returns true if the address (string) is a valid bitcoin address
 > optionally, you can specify 'prod' or 'testnet' for the type to limit validation that that subset of addresses
+
+### get_address_type (address) ###
+
+> returns address type if valid base58 address, otherwise null

--- a/index.js
+++ b/index.js
@@ -15,6 +15,33 @@ var p2sh_types = {
     testnet: 'c4'
 };
 
+/// return address type if valid base58 address, otherwise null
+function get_address_type(address) {
+    try {
+        var decoded_hex = base58.decode(address);
+    } catch (e) {
+        // if decoding fails, assume invalid address
+        return null;
+    }
+
+    // make a usable buffer from the decoded data
+    var decoded = new Buffer(decoded_hex, 'hex');
+
+    // should be 25 bytes per btc address spec
+    if (decoded.length != 25) {
+        return null;
+    }
+
+    var length = decoded.length;
+    var cksum = decoded.slice(length - 4, length).toString('binary');
+    var body = decoded.slice(0, length - 4);
+
+    var good_cksum = sha256_digest(sha256_digest(body)).substr(0,4);
+    return (cksum === good_cksum ? decoded_hex.slice(0, 2) : null);
+}
+
+module.exports.get_address_type = get_address_type;
+
 /// check if a wallet address is valid
 /// if address_type is supplied
 /// also checks that the address matches that expected version
@@ -23,38 +50,14 @@ function validate(address, address_type) {
     // default is to check that address is regular production address
     address_type = address_type || 'prod';
 
-    try {
-        var decoded_hex = base58.decode(address);
-    } catch (e) {
-        // if decoding fails, assume invalid address
+    var type = get_address_type(address);
+    if (type === null) {
         return false;
     }
 
-    // make a usable buffer from the decoded data
-    var decoded = new Buffer(decoded_hex, 'hex');
-
-    // should be 25 bytes per btc address spec
-    if (decoded.length != 25) {
+    if (type !== address_types[address_type] &&
+        type !== p2sh_types[address_type]) {
         return false;
-    }
-
-    var length = decoded.length;
-    var cksum = decoded.slice(length - 4, length).toString('binary');
-    var body = decoded.slice(0, length - 4);
-
-    var good_cksum = sha256_digest(sha256_digest(body)).substr(0,4);
-
-    if (cksum !== good_cksum) {
-        return false;
-    }
-
-    // check that the address type is correct if requested
-    if (address_type) {
-        var type = decoded_hex.slice(0, 2);
-        if (type !== address_types[address_type] &&
-            type !== p2sh_types[address_type]) {
-            return false;
-        }
     }
 
     return true;
@@ -68,6 +71,3 @@ module.exports.validate = validate;
 function sha256_digest(payload) {
     return crypto.createHash('sha256').update(payload).digest('binary');
 }
-
-
-


### PR DESCRIPTION
I refactored the base58 check into get_address_type() so the code can be used for any type of crypto currency that follows the same base58 address scheme as bitcoin does, e.g. litecoin, feathercoin, namecoin etc. Not sure if you care about this PR or not, but feel free to grab it if you do :)
