### PR TITLE
bug with strings with only leading ones

### DIFF
--- a/base58.js
+++ b/base58.js
@@ -43,6 +43,12 @@ function decode(payload) {
         hex = '0' + hex;
     }
 
+    // strings starting with only ones need to be adjusted
+    // e.g. '1' should map to '00' and not '0000'
+    if (leading_zero && !seen_other) {
+      --leading_zero;
+    }
+
     while (leading_zero-- > 0) {
         hex = '00' + hex;
     }

--- a/test/base58.js
+++ b/test/base58.js
@@ -1,0 +1,9 @@
+var decode = require('../base58').decode;
+var assert = require('assert');
+
+test('base58', function() {
+    assert.ok(decode('1') === '00');
+    assert.ok(decode('11') === '0000');
+    assert.ok(decode('1Kbn7siQHhtKRM7PsK5D6rBpgaKbHSjEiz') ===
+              '00cc0611e210e0796e092d82437be17cb0dda66aaf6b7043f7');
+});


### PR DESCRIPTION
I believe the string '1' should be decoded to '00' and not '0000'
